### PR TITLE
Use Authorization header to fetch repos

### DIFF
--- a/src/fetch-repos.js
+++ b/src/fetch-repos.js
@@ -12,9 +12,11 @@ async function fetchRepos(url) {
   while (!stopFinding) {
     await axios
       .get(url, {
+        headers: {
+          Authorization: config.access_token
+        },
         params: {
-          page,
-          access_token: config.access_token,
+          page
         },
       })
       .then(res => {


### PR DESCRIPTION
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/